### PR TITLE
Fix button widths on larger screens.

### DIFF
--- a/src/theme/_end.scss
+++ b/src/theme/_end.scss
@@ -67,7 +67,5 @@
 
   .end-button{
     margin-top: 3vh;
-    width: 60%;
   }
-
 }


### PR DESCRIPTION
Setting a 60% width on some buttons breaks them on larger screen widths.