### PR TITLE
Switch to tags for production (redux).

### DIFF
--- a/.github/workflows/hosting-production.yml
+++ b/.github/workflows/hosting-production.yml
@@ -1,9 +1,8 @@
 name: CI
 
 on:
- push:
-    branches:
-      - production
+  release:
+      types: [published]
 
 jobs:
   build:


### PR DESCRIPTION
It is easier to use GitHub's releases/tagging system to release to production. Let's avoid keeping a git-flow style master/production separation.

Redoing due to master branch change to `main`.